### PR TITLE
made events clickable

### DIFF
--- a/views/fragments/events-list.html
+++ b/views/fragments/events-list.html
@@ -1,7 +1,8 @@
 <ul>
   {% for event in events %}
     <li class = "event" id ="event-{{event.id}}">
-      {{event.title}}.
+   
+        <a href="/events/{{event.id}}"> {{event.title}}</a>.
       <time datetime="{{event.date}}">{{event.date|prettyDate}}</time>
       {{event.attending.length}} attending so far.
     </li>


### PR DESCRIPTION
The title for each event is a clickable link to the "detail page" for that event, which should be at /events/{{id}}, where id refers to the id of the event, e.g. /events/0 would take me to the event with id zero